### PR TITLE
Minor README inconsistency

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -32,7 +32,7 @@ proc httpsConnect {host port} {
 http::register http 80 ::socks5::connect
 http::register https 443 ::httpsConnect
 
-socks5::configure -proxy localhost -port 9050
+socks5::configure -proxy localhost -proxyport 9050
 
 # Retrieve check.torproject.org to confirm we are using Tor
 set token [http::geturl "https://check.torproject.org" -channel stdout]


### PR DESCRIPTION
The sample in the README uses an invalid option `-port` for `[socks5::configure]`.
It should instead be `-proxyport`.
